### PR TITLE
Fixing playback of separate video and audio

### DIFF
--- a/lib/membrane_http_adaptive_stream/hls.ex
+++ b/lib/membrane_http_adaptive_stream/hls.ex
@@ -17,9 +17,9 @@ defmodule Membrane.HTTPAdaptiveStream.HLS do
   #EXTM3U
   #EXT-X-VERSION:#{@version}
   #EXT-X-INDEPENDENT-SEGMENTS
+  #EXT-X-MEDIA:TYPE=AUDIO,NAME="a",GROUP-ID="a",AUTOSELECT=YES,DEFAULT=YES,URI="audio.m3u8"
   #EXT-X-STREAM-INF:BANDWIDTH=2560000,CODECS="avc1.42e00a",AUDIO="a"
   video.m3u8
-  #EXT-X-MEDIA:TYPE=AUDIO,NAME="a",GROUP-ID="a",AUTOSELECT=YES,DEFAULT=YES,URI="audio.m3u8"
   """
 
   defmodule SegmentAttribute do


### PR DESCRIPTION
It seems that the order of tags in master playlist was incorrect, as audio media tag was referenced before it was declared. As a result, some players (namely ffplay) didn't even start playing the stream