### PR TITLE
Fix undeterministic tests

### DIFF
--- a/lib/membrane_http_adaptive_stream/sink_bin.ex
+++ b/lib/membrane_http_adaptive_stream/sink_bin.ex
@@ -199,6 +199,7 @@ defmodule Membrane.HTTPAdaptiveStream.SinkBin do
 
   @impl true
   def handle_element_end_of_stream({:sink, _}, _ctx, %{streams_counter: 1} = state) do
+    state = Map.update!(state, :streams_counter, &(&1 - 1))
     {{:ok, notify: :end_of_stream}, state}
   end
 

--- a/lib/membrane_http_adaptive_stream/sink_bin.ex
+++ b/lib/membrane_http_adaptive_stream/sink_bin.ex
@@ -111,7 +111,12 @@ defmodule Membrane.HTTPAdaptiveStream.SinkBin do
       ] ++
         if(opts.hls_mode == :muxed_av, do: [audio_tee: Membrane.Tee.Parallel], else: [])
 
-    state = %{muxer_segment_duration: opts.muxer_segment_duration, mode: opts.hls_mode}
+    state = %{
+      muxer_segment_duration: opts.muxer_segment_duration,
+      mode: opts.hls_mode,
+      streams_counter: 0
+    }
+
     {{:ok, spec: %ParentSpec{children: children}}, state}
   end
 
@@ -168,6 +173,13 @@ defmodule Membrane.HTTPAdaptiveStream.SinkBin do
           }
       end
 
+    state =
+      Map.update!(
+        state,
+        :streams_counter,
+        &if(state.mode == :separate_av or encoding == :H264, do: &1 + 1, else: &1)
+      )
+
     {{:ok, spec: spec}, state}
   end
 
@@ -186,8 +198,14 @@ defmodule Membrane.HTTPAdaptiveStream.SinkBin do
   end
 
   @impl true
-  def handle_element_end_of_stream({:sink, _}, _ctx, state) do
+  def handle_element_end_of_stream({:sink, _}, _ctx, %{streams_counter: 1} = state) do
     {{:ok, notify: :end_of_stream}, state}
+  end
+
+  @impl true
+  def handle_element_end_of_stream({:sink, _}, _ctx, state) do
+    state = Map.update!(state, :streams_counter, &(&1 - 1))
+    {:ok, state}
   end
 
   @impl true


### PR DESCRIPTION
This PR aims to fix a race condition in tests. It turns out that it was caused by :end_of_stream notification being captured only once, even though it was being sent for each and every input pad of the sink - we were terminating the pipeline in the exact moment that the FIRST stream finished processing
