### PR TITLE
Order `add_segment` arguments properly

### DIFF
--- a/lib/membrane_http_adaptive_stream/bandwidth_calculator.ex
+++ b/lib/membrane_http_adaptive_stream/bandwidth_calculator.ex
@@ -22,7 +22,7 @@ defmodule Membrane.HTTPAdaptiveStream.BandwidthCalculator do
       segments_sequences
       |> Enum.map(
         &{
-          Enum.map(&1, fn sg -> 8 * sg.bytes_size end) |> Enum.sum(),
+          Enum.map(&1, fn sg -> 8 * sg.byte_size end) |> Enum.sum(),
           Enum.map(&1, fn sg -> sg.duration / Time.second() end)
           |> Enum.reduce(fn acc, x -> acc + x end)
         }

--- a/lib/membrane_http_adaptive_stream/manifest.ex
+++ b/lib/membrane_http_adaptive_stream/manifest.ex
@@ -32,15 +32,15 @@ defmodule Membrane.HTTPAdaptiveStream.Manifest do
           t,
           track_id :: Track.id_t(),
           Track.segment_duration_t(),
-          Track.segment_bytes_size_t(),
+          Track.segment_byte_size_t(),
           list(__MODULE__.SegmentAttribute.t())
         ) ::
           {{to_add_name :: String.t(), to_remove_names :: Track.to_remove_names_t()}, t}
-  def add_segment(%__MODULE__{} = manifest, track_id, duration, bytes_size, attributes \\ []) do
+  def add_segment(%__MODULE__{} = manifest, track_id, duration, byte_size, attributes \\ []) do
     get_and_update_in(
       manifest,
       [:tracks, track_id],
-      &Track.add_segment(&1, duration, bytes_size, attributes)
+      &Track.add_segment(&1, duration, byte_size, attributes)
     )
   end
 

--- a/lib/membrane_http_adaptive_stream/manifest/track.ex
+++ b/lib/membrane_http_adaptive_stream/manifest/track.ex
@@ -110,12 +110,12 @@ defmodule Membrane.HTTPAdaptiveStream.Manifest.Track do
           Qex.t(%{
             name: String.t(),
             duration: segment_duration_t(),
-            bytes_size: segment_bytes_size_t(),
+            byte_size: segment_byte_size_t(),
             attributes: list(Manifest.SegmentAttribute.t())
           })
   @type segment_duration_t :: Membrane.Time.t() | Ratio.t()
 
-  @type segment_bytes_size_t :: non_neg_integer()
+  @type segment_byte_size_t :: non_neg_integer()
 
   @type to_remove_names_t :: [segment_names: [String.t()], header_names: [String.t()]]
 
@@ -150,13 +150,13 @@ defmodule Membrane.HTTPAdaptiveStream.Manifest.Track do
   @spec add_segment(
           t,
           segment_duration_t,
-          segment_bytes_size_t,
+          segment_byte_size_t,
           list(Manifest.SegmentAttribute.t())
         ) ::
           {{to_add_name :: String.t(), to_remove_names :: to_remove_names_t()}, t}
-  def add_segment(track, duration, bytes_size, attributes \\ [])
+  def add_segment(track, duration, byte_size, attributes \\ [])
 
-  def add_segment(%__MODULE__{finished?: false} = track, duration, bytes_size, attributes) do
+  def add_segment(%__MODULE__{finished?: false} = track, duration, byte_size, attributes) do
     use Ratio, comparison: true
 
     name = track.segment_naming_fun.(track) <> track.segment_extension
@@ -173,7 +173,7 @@ defmodule Membrane.HTTPAdaptiveStream.Manifest.Track do
         &Qex.push(&1, %{
           name: name,
           duration: duration,
-          bytes_size: bytes_size,
+          byte_size: byte_size,
           attributes: attributes
         })
       )
@@ -206,7 +206,7 @@ defmodule Membrane.HTTPAdaptiveStream.Manifest.Track do
      %__MODULE__{track | stale_segments: stale_segments, stale_headers: stale_headers}}
   end
 
-  def add_segment(%__MODULE__{finished?: true} = _track, _duration, _bytes_size, _attributes),
+  def add_segment(%__MODULE__{finished?: true} = _track, _duration, _byte_size, _attributes),
     do: raise("Cannot add new segments to finished track")
 
   @doc """

--- a/lib/membrane_http_adaptive_stream/manifest/track.ex
+++ b/lib/membrane_http_adaptive_stream/manifest/track.ex
@@ -156,7 +156,7 @@ defmodule Membrane.HTTPAdaptiveStream.Manifest.Track do
           {{to_add_name :: String.t(), to_remove_names :: to_remove_names_t()}, t}
   def add_segment(track, duration, bytes_size, attributes \\ [])
 
-  def add_segment(%__MODULE__{finished?: false} = track, bytes_size, duration, attributes) do
+  def add_segment(%__MODULE__{finished?: false} = track, duration, bytes_size, attributes) do
     use Ratio, comparison: true
 
     name = track.segment_naming_fun.(track) <> track.segment_extension

--- a/lib/membrane_http_adaptive_stream/sink.ex
+++ b/lib/membrane_http_adaptive_stream/sink.ex
@@ -176,7 +176,7 @@ defmodule Membrane.HTTPAdaptiveStream.Sink do
     duration = buffer.metadata.duration
 
     {changeset, manifest} =
-      Manifest.add_segment(manifest, id, byte_size(buffer.payload), duration)
+      Manifest.add_segment(manifest, id, duration, byte_size(buffer.payload))
 
     state = %{state | manifest: manifest}
 

--- a/test/membrane_http_adaptive_stream/bandwidth_calculator_test.exs
+++ b/test/membrane_http_adaptive_stream/bandwidth_calculator_test.exs
@@ -36,7 +36,7 @@ defmodule Membrane.HTTPAdaptiveStream.BandwidthCalculatorTest do
     %{
       name: "mock_segment",
       duration: duration,
-      bytes_size: byte_size,
+      byte_size: byte_size,
       attributes: []
     }
   end


### PR DESCRIPTION
`Sink` has been calling manifest with incorrect order of arguments...
```elixir
  Manifest.add_segment(manifest, id, byte_size(buffer.payload), duration)
```
...when `Manifest.add_segment` definition is...
```elixir
  def add_segment(%__MODULE__{} = manifest, track_id, duration, bytes_size, attributes \\ []) do
    ...
    &Track.add_segment(&1, duration, bytes_size, attributes)
```
...but this was again reordered in `Track`...
```elixir
  def add_segment(%__MODULE__{finished?: false} = track, bytes_size, duration, attributes) do
```
...despite it's general header and spec say the order of arguments should be...
```elixir
   def add_segment(track, duration, bytes_size, attributes \\ [])
```

![juggler](https://i.pinimg.com/originals/55/5e/9c/555e9ca47511603a7a91354c66781a60.gif)