### PR TITLE
Delta manifest / Skipping old segments in ll-hls

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ In future, the support for MPEG-DASH is planned as well
 Add the following line to your `deps` in `mix.exs`. Run `mix deps.get`.
 
 ```elixir
-	{:membrane_http_adaptive_stream_plugin, "~> 0.13.0"}
+	{:membrane_http_adaptive_stream_plugin, "~> 0.14.0"}
 ```
 
 ## Usage Example

--- a/lib/membrane_http_adaptive_stream/hls.ex
+++ b/lib/membrane_http_adaptive_stream/hls.ex
@@ -126,7 +126,7 @@ defmodule Membrane.HTTPAdaptiveStream.HLS do
     if should_generate_delta_playlist? do
       delta_path = build_media_playlist_path(track, delta?: true)
       serialized_delta_track = {delta_path, serialize_track(track, delta?: true)}
-      Map.put(tracks_map, track.id, serialized_delta_track)
+      Map.put(tracks_map, :"#{track.id}_delta", serialized_delta_track)
     else
       tracks_map
     end

--- a/lib/membrane_http_adaptive_stream/hls.ex
+++ b/lib/membrane_http_adaptive_stream/hls.ex
@@ -94,12 +94,15 @@ defmodule Membrane.HTTPAdaptiveStream.HLS do
     case tracks do
       %{muxed: tracks} ->
         serialize_tracks(tracks)
+
       %{audio: audios, video: videos} ->
         serialized_videos = serialize_tracks(videos)
         serialized_audios = serialize_tracks(audios)
         Map.merge(serialized_videos, serialized_audios)
+
       %{audio: audios} ->
         serialize_tracks(audios)
+
       %{video: videos} ->
         serialize_tracks(videos)
     end

--- a/lib/membrane_http_adaptive_stream/hls.ex
+++ b/lib/membrane_http_adaptive_stream/hls.ex
@@ -202,7 +202,7 @@ defmodule Membrane.HTTPAdaptiveStream.HLS do
     can_skip_segments_duration =
       if supports_ll_hls? do
         track.segments
-        |> Enum.drop(-6)
+        |> Enum.drop(-@min_segments_in_delta_playlist)
         |> Enum.reduce(0, &(&1.duration + &2))
         |> then(&Ratio.to_float(&1 / Time.second()))
       else

--- a/lib/membrane_http_adaptive_stream/hls.ex
+++ b/lib/membrane_http_adaptive_stream/hls.ex
@@ -133,11 +133,13 @@ defmodule Membrane.HTTPAdaptiveStream.HLS do
     )
   end
 
+  defp build_media_playlist_path(track, opts \\ [delta?: false])
+
   defp build_media_playlist_path(%Track{} = track, delta?: true) do
     track.track_name <> "_delta.m3u8"
   end
 
-  defp build_media_playlist_path(%Track{} = track, _opts \\ []) do
+  defp build_media_playlist_path(%Track{} = track, delta?: false) do
     track.track_name <> ".m3u8"
   end
 
@@ -194,7 +196,7 @@ defmodule Membrane.HTTPAdaptiveStream.HLS do
   end
 
   defp serialize_track(%Track{} = track, [delta?: delta?] \\ [delta?: false]) do
-    target_duration = Ratio.ceil(track.segment_duration.target / Time.second()) |> trunc()
+    target_duration = Ratio.ceil(track.segment_duration / Time.second()) |> trunc()
     supports_ll_hls? = Track.supports_partial_segments?(track)
 
     can_skip_segments_duration =

--- a/lib/membrane_http_adaptive_stream/hls.ex
+++ b/lib/membrane_http_adaptive_stream/hls.ex
@@ -125,7 +125,7 @@ defmodule Membrane.HTTPAdaptiveStream.HLS do
         do:
           Map.put(
             &1,
-            :"#{Atom.to_string(track.id)}_delta",
+            :"#{track.id}_delta",
             {build_media_playlist_path(track, delta?: true), serialize_track(track, delta?: true)}
           ),
         else: &1

--- a/log
+++ b/log
@@ -1,7 +1,0 @@
-Compiling 1 file (.ex)
-..............
-
-Finished in 28.3 seconds (28.3s async, 0.00s sync)
-14 tests, 0 failures
-
-Randomized with seed 899714

--- a/log
+++ b/log
@@ -1,0 +1,38 @@
+..........[
+  ["#EXTINF:2.8,\nvideo_segment_3_video_720x480.m4s"],
+  ["#EXTINF:3.0,\nvideo_segment_4_video_720x480.m4s"],
+  ["#EXTINF:2.0,\nvideo_segment_5_video_720x480.m4s"],
+  ["#EXTINF:3.92,\nvideo_segment_6_video_720x480.m4s"],
+  ["#EXTINF:5.04,\nvideo_segment_7_video_720x480.m4s"],
+  ["#EXTINF:2.52,\nvideo_segment_8_video_720x480.m4s"]
+]
+[
+  ["#EXTINF:2.8,\nvideo_segment_4_video_480x270.m4s"],
+  ["#EXTINF:2.88,\nvideo_segment_5_video_480x270.m4s"],
+  ["#EXTINF:4.8,\nvideo_segment_6_video_480x270.m4s"],
+  ["#EXTINF:2.32,\nvideo_segment_7_video_480x270.m4s"],
+  ["#EXTINF:3.96,\nvideo_segment_8_video_480x270.m4s"],
+  ["#EXTINF:2.52,\nvideo_segment_9_video_480x270.m4s"]
+]
+[
+  ["#EXTINF:2.8,\nvideo_segment_3_video_540x360.m4s"],
+  ["#EXTINF:2.96,\nvideo_segment_4_video_540x360.m4s"],
+  ["#EXTINF:2.0,\nvideo_segment_5_video_540x360.m4s"],
+  ["#EXTINF:3.96,\nvideo_segment_6_video_540x360.m4s"],
+  ["#EXTINF:5.04,\nvideo_segment_7_video_540x360.m4s"],
+  ["#EXTINF:2.52,\nvideo_segment_8_video_540x360.m4s"]
+]
+[
+  ["#EXTINF:2.438095235,\naudio_segment_8_audio_track.m4s"],
+  ["#EXTINF:2.438095235,\naudio_segment_9_audio_track.m4s"],
+  ["#EXTINF:2.438095235,\naudio_segment_10_audio_track.m4s"],
+  ["#EXTINF:2.438095235,\naudio_segment_11_audio_track.m4s"],
+  ["#EXTINF:2.438095235,\naudio_segment_12_audio_track.m4s"],
+  ["#EXTINF:1.346757368,\naudio_segment_13_audio_track.m4s"]
+]
+....
+
+Finished in 37.3 seconds (37.3s async, 0.00s sync)
+14 tests, 0 failures
+
+Randomized with seed 379020

--- a/log
+++ b/log
@@ -1,38 +1,7 @@
-..........[
-  ["#EXTINF:2.8,\nvideo_segment_3_video_720x480.m4s"],
-  ["#EXTINF:3.0,\nvideo_segment_4_video_720x480.m4s"],
-  ["#EXTINF:2.0,\nvideo_segment_5_video_720x480.m4s"],
-  ["#EXTINF:3.92,\nvideo_segment_6_video_720x480.m4s"],
-  ["#EXTINF:5.04,\nvideo_segment_7_video_720x480.m4s"],
-  ["#EXTINF:2.52,\nvideo_segment_8_video_720x480.m4s"]
-]
-[
-  ["#EXTINF:2.8,\nvideo_segment_4_video_480x270.m4s"],
-  ["#EXTINF:2.88,\nvideo_segment_5_video_480x270.m4s"],
-  ["#EXTINF:4.8,\nvideo_segment_6_video_480x270.m4s"],
-  ["#EXTINF:2.32,\nvideo_segment_7_video_480x270.m4s"],
-  ["#EXTINF:3.96,\nvideo_segment_8_video_480x270.m4s"],
-  ["#EXTINF:2.52,\nvideo_segment_9_video_480x270.m4s"]
-]
-[
-  ["#EXTINF:2.8,\nvideo_segment_3_video_540x360.m4s"],
-  ["#EXTINF:2.96,\nvideo_segment_4_video_540x360.m4s"],
-  ["#EXTINF:2.0,\nvideo_segment_5_video_540x360.m4s"],
-  ["#EXTINF:3.96,\nvideo_segment_6_video_540x360.m4s"],
-  ["#EXTINF:5.04,\nvideo_segment_7_video_540x360.m4s"],
-  ["#EXTINF:2.52,\nvideo_segment_8_video_540x360.m4s"]
-]
-[
-  ["#EXTINF:2.438095235,\naudio_segment_8_audio_track.m4s"],
-  ["#EXTINF:2.438095235,\naudio_segment_9_audio_track.m4s"],
-  ["#EXTINF:2.438095235,\naudio_segment_10_audio_track.m4s"],
-  ["#EXTINF:2.438095235,\naudio_segment_11_audio_track.m4s"],
-  ["#EXTINF:2.438095235,\naudio_segment_12_audio_track.m4s"],
-  ["#EXTINF:1.346757368,\naudio_segment_13_audio_track.m4s"]
-]
-....
+Compiling 1 file (.ex)
+..............
 
-Finished in 37.3 seconds (37.3s async, 0.00s sync)
+Finished in 28.3 seconds (28.3s async, 0.00s sync)
 14 tests, 0 failures
 
-Randomized with seed 379020
+Randomized with seed 899714

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.HTTPAdaptiveStream.MixProject do
   use Mix.Project
 
-  @version "0.13.0"
+  @version "0.14.0"
   @github_url "https://github.com/membraneframework/membrane_http_adaptive_stream_plugin"
 
   def project do

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Membrane.HTTPAdaptiveStream.MixProject do
     [
       app: :membrane_http_adaptive_stream_plugin,
       version: @version,
-      elixir: "~> 1.12",
+      elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),
@@ -63,7 +63,7 @@ defmodule Membrane.HTTPAdaptiveStream.MixProject do
 
   defp deps do
     [
-      {:membrane_core, "~> 0.11.2"},
+      {:membrane_core, "~> 0.11.3"},
       {:membrane_cmaf_format, "~> 0.6.1"},
       {:membrane_tee_plugin, "~> 0.10.1"},
       {:membrane_mp4_plugin, "~> 0.21.0"},

--- a/test/membrane_http_adaptive_stream/integration_test/sink_bin_integration_test.exs
+++ b/test/membrane_http_adaptive_stream/integration_test/sink_bin_integration_test.exs
@@ -228,9 +228,6 @@ defmodule Membrane.HTTPAdaptiveStream.SinkBinIntegrationTest do
       assert_pipeline_play(pipeline)
       assert_pipeline_notified(pipeline, :sink_bin, :end_of_stream, 10_000)
 
-      # Give some time to save all of the files to disk
-      Process.sleep(10_000)
-
       File.ls!(tmp_dir)
       |> Enum.filter(&String.match?(&1, ~r/.*(?<!index|delta)\.m3u8$/))
       |> Enum.each(fn manifest_filename ->
@@ -300,9 +297,6 @@ defmodule Membrane.HTTPAdaptiveStream.SinkBinIntegrationTest do
 
       assert_pipeline_play(pipeline)
       assert_pipeline_notified(pipeline, :sink_bin, :end_of_stream, 10_000)
-
-      # Give some time to save all of the files to disk
-      Process.sleep(1_000)
 
       assert_receive {SendStorage, :store, %{type: :manifest, name: "index.m3u8"}}, 1_000
 
@@ -381,9 +375,6 @@ defmodule Membrane.HTTPAdaptiveStream.SinkBinIntegrationTest do
     assert_pipeline_play(pipeline)
 
     assert_pipeline_notified(pipeline, :sink_bin, :end_of_stream, 10_000)
-
-    # Give some time to save all of the files to disk
-    Process.sleep(1_000)
 
     :ok = Testing.Pipeline.terminate(pipeline, blocking?: true)
   end

--- a/test/membrane_http_adaptive_stream/integration_test/sink_bin_integration_test.exs
+++ b/test/membrane_http_adaptive_stream/integration_test/sink_bin_integration_test.exs
@@ -17,6 +17,8 @@ defmodule Membrane.HTTPAdaptiveStream.SinkBinIntegrationTest do
   }
   @create_fixtures false
 
+  @expected_number_of_segments_in_delta_playlist 6
+
   @audio_video_tracks_sources [
     {"http://raw.githubusercontent.com/membraneframework/static/gh-pages/samples/test-audio.aac",
      :AAC, "audio_track"},
@@ -195,6 +197,82 @@ defmodule Membrane.HTTPAdaptiveStream.SinkBinIntegrationTest do
         tmp_dir,
         pipeline_config
       )
+    end
+
+    @tag :tmp_dir
+    test "test creation of delta playlist", %{tmp_dir: tmp_dir} do
+      alias Membrane.HTTPAdaptiveStream.Storages.FileStorage
+
+      hackney_sources =
+        @audio_multiple_video_tracks_sources
+        |> Enum.map(fn {path, encoding, name} ->
+          {%Membrane.Hackney.Source{location: path, hackney_opts: [follow_redirect: true]},
+           encoding, name}
+        end)
+
+      pipeline =
+        Testing.Pipeline.start_link_supervised!(
+          module: TestPipeline,
+          custom_args: %{
+            sources: hackney_sources,
+            hls_mode: @pipeline_config.hls_mode,
+            partial_segments: true,
+            target_window_duration: @pipeline_config.target_window_duration,
+            persist?: @pipeline_config.persist?,
+            storage: %FileStorage{
+              directory: tmp_dir
+            }
+          }
+        )
+
+      assert_pipeline_play(pipeline)
+      assert_pipeline_notified(pipeline, :sink_bin, :end_of_stream, 10_000)
+
+      # Give some time to save all of the files to disk
+      Process.sleep(10_000)
+
+      File.ls!(tmp_dir)
+      |> Enum.filter(&String.match?(&1, ~r/.*(?<!index|delta)\.m3u8$/))
+      |> Enum.each(fn manifest_filename ->
+        manifest_file = File.read!(Path.join(tmp_dir, manifest_filename))
+
+        segments_in_manifest =
+          Regex.scan(~r/#EXTINF:\d+\.\d+,\s\w+segment_\d+_.+.m4s/, manifest_file)
+
+        number_of_segments_in_manifest = Enum.count(segments_in_manifest)
+        # delta manifest will be generated when plailist is longer then 6 segments
+        if number_of_segments_in_manifest > @expected_number_of_segments_in_delta_playlist do
+          # check if manifest contains CAN-SKIP-UNTIL tag
+          assert Regex.match?(~r/CAN-SKIP-UNTIL=\d+\.*\d*/, manifest_file)
+
+          # check if delta file exists
+          delta_manifest_filename = String.replace(manifest_filename, ".m3u8", "_delta.m3u8")
+          assert File.exists?(Path.join(tmp_dir, delta_manifest_filename))
+
+          delta_manifest_file = File.read!(Path.join(tmp_dir, delta_manifest_filename))
+
+          segments_in_delta_manifest =
+            Regex.scan(~r/#EXTINF:\d+\.\d+,\s\w+segment_\d+_.+.m4s/, delta_manifest_file)
+
+          number_of_segments_in_delta_manifest = Enum.count(segments_in_delta_manifest)
+          # check if delta manifest contains exected number of segments
+          assert number_of_segments_in_delta_manifest ==
+                   @expected_number_of_segments_in_delta_playlist
+
+          # check if delta manifest contains last 6 segments from manifest
+          assert Enum.take(segments_in_manifest, -@expected_number_of_segments_in_delta_playlist) ==
+                   segments_in_delta_manifest
+
+          # check if delta manifest contains #EXT-X-SKIP tag with correct value
+          [_match, skipped_segments] =
+            Regex.run(~r/EXT-X-SKIP:SKIPPED-SEGMENTS=(\d+)/, delta_manifest_file)
+
+          {skipped_segments, _rest} = Integer.parse(skipped_segments)
+
+          assert skipped_segments + number_of_segments_in_delta_manifest ==
+                   number_of_segments_in_manifest
+        end
+      end)
     end
 
     test "audio and video tracks with partial segments" do


### PR DESCRIPTION
PR adds option to skip old segments in live playlist for ll-hls.

1. Adds CAN-SKIP-UNTIL tag when playlist is longer then 6 regular segments
2. Creates delta manifests for streams longer than 6 segments by adding `EXT-X-SKIP` tag and skipping old segments
3. Creates separate `*.m3u8` files fith `_delta` suffix to store delta playlist. Files should be send to client instead of regular manifest when request contains `_HLS_SKIP` parameter