### PR TITLE
Remove accepted h264 profiles restriction. Bump to v0.16.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ In future, the support for MPEG-DASH is planned as well
 Add the following line to your `deps` in `mix.exs`. Run `mix deps.get`.
 
 ```elixir
-	{:membrane_http_adaptive_stream_plugin, "~> 0.15.0"}
+	{:membrane_http_adaptive_stream_plugin, "~> 0.16.1"}
 ```
 
 ## Usage Example

--- a/lib/membrane_http_adaptive_stream/sink_bin.ex
+++ b/lib/membrane_http_adaptive_stream/sink_bin.ex
@@ -100,14 +100,12 @@ defmodule Membrane.HTTPAdaptiveStream.SinkBin do
                 """
               ]
 
-  @accepted_h264_profiles [:constrained_baseline, :baseline, :high]
-
   def_input_pad :input,
     demand_unit: :buffers,
     accepted_format:
       any_of(
         Membrane.AAC,
-        %Membrane.H264{profile: profile} when profile in @accepted_h264_profiles
+        Membrane.H264
       ),
     availability: :on_request,
     options: [
@@ -115,8 +113,6 @@ defmodule Membrane.HTTPAdaptiveStream.SinkBin do
         spec: :AAC | :H264,
         description: """
         Encoding type determining which payloader will be used for the given stream.
-
-        For H264, the accepted profiles are #{Enum.map_join(@accepted_h264_profiles, ", ", &inspect/1)}.
         """
       ],
       track_name: [

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.HTTPAdaptiveStream.MixProject do
   use Mix.Project
 
-  @version "0.16.0"
+  @version "0.16.1"
   @github_url "https://github.com/membraneframework/membrane_http_adaptive_stream_plugin"
 
   def project do


### PR DESCRIPTION
closes #80 