### PR TITLE
Fix "PART-HOLD-BACK" warning on Safari

### DIFF
--- a/lib/membrane_http_adaptive_stream/hls.ex
+++ b/lib/membrane_http_adaptive_stream/hls.ex
@@ -332,7 +332,7 @@ defmodule Membrane.HTTPAdaptiveStream.HLS do
         Float.ceil(Ratio.to_float(track.partial_segment_duration / Time.second()), 3)
 
       """
-      #EXT-X-SERVER-CONTROL:CAN-BLOCK-RELOAD=YES,PART-HOLD-BACK=#{2 * target_partial_duration}#{can_skip_until(can_skip_segments_duration)}
+      #EXT-X-SERVER-CONTROL:CAN-BLOCK-RELOAD=YES,PART-HOLD-BACK=#{3 * target_partial_duration}#{can_skip_until(can_skip_segments_duration)}
       #EXT-X-PART-INF:PART-TARGET=#{target_partial_duration}
       """
     else


### PR DESCRIPTION
```
Warning: PART-HOLD-BACK SHOULD be at least three times the Part Target Duration
--> Detail:  Part hold back: 0.802000, Part target: 0.401000
--> Source:  g2QABXZpZGVv.m3u8
```