### PR TITLE
Add EXT-X-STREAM-INF for audio only track

### DIFF
--- a/lib/membrane_http_adaptive_stream/hls.ex
+++ b/lib/membrane_http_adaptive_stream/hls.ex
@@ -196,11 +196,15 @@ defmodule Membrane.HTTPAdaptiveStream.HLS do
         |> String.trim()
 
       %Track{content_type: type} when type in [:video, :muxed] ->
-        """
-        #EXT-X-STREAM-INF:#{serialize_bandwidth(track)}#{serialize_resolution(track)}#{serialize_framerate(track)}#{serialize_encoding(track)}
-        """
-        |> String.trim()
+        build_variant_stream_tag(track)
     end
+  end
+
+  defp build_variant_stream_tag(%Track{} = track) do
+    """
+    #EXT-X-STREAM-INF:#{serialize_bandwidth(track)}#{serialize_resolution(track)}#{serialize_framerate(track)}#{serialize_encoding(track)}
+    """
+    |> String.trim()
   end
 
   defp serialize_bandwidth(track) do
@@ -247,8 +251,8 @@ defmodule Membrane.HTTPAdaptiveStream.HLS do
   defp build_master_playlist(tracks) do
     case tracks do
       {audio, nil} ->
-        [@master_playlist_header, build_media_playlist_tag(audio)]
-        |> Enum.join("")
+        [@master_playlist_header, build_media_playlist_tag(audio), build_variant_stream_tag(audio), build_media_playlist_path(audio)]
+        |> Enum.join("\n")
 
       {nil, videos} ->
         [


### PR DESCRIPTION
A fix for audio- only streams.

For cases like below where the video pad of the hls_sink_bin has nothing passed into it:

```elixir
child(:rtmp_source, %Membrane.RTMP.SourceBin{client_ref: client_ref})
|> via_out(:audio)
|> child(:rtmp_in_aac_parser, Membrane.AAC.Parser)
|> child(:rtmp_in_aac_decoder, Membrane.AAC.FDK.Decoder),
child(
  :hls_sink_bin,
  %Membrane.HTTPAdaptiveStream.SinkBin{
    manifest_name: manifest_name,
    manifest_module: Membrane.HTTPAdaptiveStream.HLS,
    storage: %Membrane.HTTPAdaptiveStream.Storages.FileStorage{
      directory: directory
    },
    hls_mode: hls_mode,
    mp4_parameters_in_band?: true,
    target_window_duration: Membrane.Time.seconds(20)
  }
),
# AUDIO BUILDER
get_child(:rtmp_in_aac_decoder)
|> child(:hls_out_aac_encoder, Membrane.AAC.FDK.Encoder)
|> via_in(Pad.ref(:input, :audio),
  options: [encoding: :AAC, segment_duration: Membrane.Time.milliseconds(2000)]
)
|> get_child(:hls_sink_bin),

# FAKE VIDEO BUILDER
get_child(:rtmp_source) |> via_out(:video)
|> child(:fake_sink, Membrane.Fake.Sink.Buffers)
```