### PR TITLE
fix wrong message topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ In future, the support for MPEG-DASH is planned as well
 Add the following line to your `deps` in `mix.exs`. Run `mix deps.get`.
 
 ```elixir
-	{:membrane_http_adaptive_stream_plugin, "~> 0.18.6"}
+	{:membrane_http_adaptive_stream_plugin, "~> 0.18.7"}
 ```
 
 ## Usage Example

--- a/lib/membrane_http_adaptive_stream/storages/genserver_storage.ex
+++ b/lib/membrane_http_adaptive_stream/storages/genserver_storage.ex
@@ -55,6 +55,6 @@ defmodule Membrane.HTTPAdaptiveStream.Storages.GenServerStorage do
   @impl true
   def remove(parent_id, name, context, impl_state) do
     params = Map.merge(context, %{parent_id: parent_id, name: name})
-    {impl_state.method.(impl_state.destination, {__MODULE__, :store, params}), impl_state}
+    {impl_state.method.(impl_state.destination, {__MODULE__, :remove, params}), impl_state}
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.HTTPAdaptiveStream.MixProject do
   use Mix.Project
 
-  @version "0.18.6"
+  @version "0.18.7"
   @github_url "https://github.com/membraneframework/membrane_http_adaptive_stream_plugin"
 
   def project do

--- a/test/membrane_http_adaptive_stream/integration_test/sink_bin_integration_test.exs
+++ b/test/membrane_http_adaptive_stream/integration_test/sink_bin_integration_test.exs
@@ -428,7 +428,7 @@ defmodule Membrane.HTTPAdaptiveStream.SinkBinIntegrationTest do
       preload_hints =
         expected_segments
         |> Enum.flat_map(fn {_type, _segment_idx, parts} = tuple ->
-          for idx <- 0..parts, do: Tuple.append(tuple, idx)
+          for idx <- 0..parts, do: Tuple.insert_at(tuple, 3, idx)
         end)
         |> Enum.map(fn {type, segment_idx, parts, part_idx} ->
           {segment_idx, part_idx} = calculate_preload_sn(segment_idx, part_idx, parts)


### PR DESCRIPTION
That's probably a quite obvious fix.

Fix in integration test is because `Tupple.append/2` is deprecated since Elixir 1.18